### PR TITLE
Add Kodify link to 'more information' page

### DIFF
--- a/source/Where_can_I_get_more_information.rst
+++ b/source/Where_can_I_get_more_information.rst
@@ -20,3 +20,9 @@ Fourth, there is a Pine Script community growing on StackOverflow, see questions
 Finally, information about large releases and modifications to Pine
 Script (as well as other features) is regularly published on
 `TradingView's blog <http://blog.tradingview.com>`__.
+
+
+External resources
+-------------------
+
+-  `TradingView programming articles <https://kodify.net/tradingview-programming-articles/>`__.


### PR DESCRIPTION
Hi there!

This pull request proposes to add Kodify (my website) to the 'Where can I get more information?'-page, just like it is on the [original wiki page](https://www.tradingview.com/wiki/Where_can_I_get_more_information%3F).

Feedback and comments are welcome, it's my first pull request here after all. :slightly_smiling_face: 

Thanks for your consideration,